### PR TITLE
Clarify repo licensing and add per-notebook headers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -394,6 +394,16 @@ Evalscripts that work with time series or temporal composites require different 
 
 Converting evalscripts to openEO UDPs makes valuable algorithms accessible across the entire openEO ecosystem while maintaining their utility for real-time exploration and analysis. Your contributions help build a library of interoperable Earth observation processes that benefit researchers, operational users, and educators worldwide.
 
+## Licensing
+
+This repository uses a mixed-licensing approach:
+
+- **Default license**: MIT (see `LICENSE`).
+- **Converted Sentinel Hub evalscripts**: must remain **CC-BY-SA-4.0**.
+
+If you convert a Sentinel Hub evalscript, add a clear file header that states the
+origin and license. See `LICENSING.md` for the required template and examples.
+
 Thank you for contributing to this important work. Your efforts make Earth observation more open, accessible, and interoperable for everyone.
 
 ---

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Development Seed
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,56 @@
+# Licensing
+
+This repository uses a mixed-licensing approach.
+
+## Default license (repo-level)
+
+Unless stated otherwise in a file header, all original work in this repository is
+licensed under the **MIT License** (see `LICENSE`).
+
+## Converted Sentinel Hub evalscripts
+
+Files that are converted from Sentinel Hub Custom Scripts **must retain the
+original license**. The Sentinel Hub Custom Scripts are published under
+**CC-BY-SA-4.0**, so converted files are also **CC-BY-SA-4.0**.
+
+To keep this clear and non-viral, every converted file must include an explicit
+header that states:
+
+- The origin (converted from Sentinel Hub)
+- The license that applies to that file (CC-BY-SA-4.0)
+- A link to the original evalscript
+
+This makes it clear that CC-BY-SA-4.0 applies only to those converted files, not
+to the rest of the repository.
+
+## Required header template
+
+Use the following template at the top of each converted file.
+
+### Jupyter notebook (first markdown cell)
+
+```
+## License
+
+This notebook is a conversion of a Sentinel Hub evalscript and is licensed under
+**CC-BY-SA-4.0**.
+
+Original evalscript: <link>
+Source: Sentinel Hub Custom Scripts (CC-BY-SA-4.0)
+Conversion: Development Seed (openEO-UDP project)
+```
+
+### Code file (file header comment)
+
+```
+# License: CC-BY-SA-4.0
+# Origin: Converted from Sentinel Hub evalscript
+# Original evalscript: <link>
+# Source: Sentinel Hub Custom Scripts (CC-BY-SA-4.0)
+# Conversion: Development Seed (openEO-UDP project)
+```
+
+## Current CC-BY-SA-4.0 files
+
+- `notebooks/sentinel/sentinel-2/fire_and_disaster_monitoring/bais2_burned_area.ipynb`
+- `notebooks/sentinel/sentinel-2/marine_and_water_bodies/ndci_cyanobacteria.ipynb`

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Each notebook includes specific attribution to the original script authors and l
 
 ## License
 
-This project is licensed under the Apache License 2.0, consistent with the openEO ecosystem and Sentinel Hub custom scripts.
+This project is licensed under the MIT License by default, with CC-BY-SA-4.0 applied to converted Sentinel Hub evalscripts. See [`LICENSING.md`](./LICENSING.md) for details.
 
 ## Acknowledgments
 

--- a/notebooks/sentinel/sentinel-2/fire_and_disaster_monitoring/bais2_burned_area.ipynb
+++ b/notebooks/sentinel/sentinel-2/fire_and_disaster_monitoring/bais2_burned_area.ipynb
@@ -2,6 +2,20 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## License\n",
+    "\n",
+    "This notebook is a conversion of a Sentinel Hub evalscript and is licensed under\n",
+    "**CC-BY-SA-4.0**.\n",
+    "\n",
+    "Original evalscript: https://custom-scripts.sentinel-hub.com/sentinel-2/bais2/\n",
+    "Source: Sentinel Hub Custom Scripts (CC-BY-SA-4.0)\n",
+    "Conversion: Development Seed (openEO-UDP project)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "bed583f9",
    "metadata": {},
    "source": [

--- a/notebooks/sentinel/sentinel-2/marine_and_water_bodies/ndci_cyanobacteria.ipynb
+++ b/notebooks/sentinel/sentinel-2/marine_and_water_bodies/ndci_cyanobacteria.ipynb
@@ -4,6 +4,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## License\n",
+    "\n",
+    "This notebook is a conversion of a Sentinel Hub evalscript and is licensed under\n",
+    "**CC-BY-SA-4.0**.\n",
+    "\n",
+    "Original evalscript: https://custom-scripts.sentinel-hub.com/sentinel-2/cyanobacteria_chla_ndci_l1c/\n",
+    "Source: Sentinel Hub Custom Scripts (CC-BY-SA-4.0)\n",
+    "Conversion: Development Seed (openEO-UDP project)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Cyanobacteria Chlorophyll-a Detection with NDCI and OpenEO\n",
     "\n",
     "This notebook demonstrates how to detect and quantify cyanobacteria chlorophyll-a concentrations in water bodies using Sentinel-2 imagery and the Normalized Difference Chlorophyll Index (NDCI) with the OpenEO API.\n",


### PR DESCRIPTION
Adopt MIT as default with CC-BY-SA-4.0 for converted evalscripts, add LICENSING.md, update docs, and insert license headers in converted notebooks.

Closes #2 